### PR TITLE
feat(cli): support MAPQUEST_API_KEY env var as --api-key fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ This package provides a command-line tool that, given a city or town name, retri
   - `mapquest-geocode "CITY_OR_TOWN_NAME" --api-key YOUR_API_KEY`
   - Example:
     - `mapquest-geocode "New York" --api-key YOUR_API_KEY`
+
+### Providing the API key
+
+The API key can be supplied in either of two ways:
+
+- `--api-key` flag (takes precedence):
+  - `mapquest-geocode "New York" --api-key YOUR_API_KEY`
+- `MAPQUEST_API_KEY` environment variable (used when `--api-key` is omitted):
+  - `export MAPQUEST_API_KEY=YOUR_API_KEY`
+  - `mapquest-geocode "New York"`
+
+If neither is provided, the command exits with an error.

--- a/mapquest_geocoder/geocode.py
+++ b/mapquest_geocoder/geocode.py
@@ -1,7 +1,10 @@
 import argparse
+import os
 import sys
 
 import requests
+
+API_KEY_ENV_VAR = "MAPQUEST_API_KEY"
 
 # HTTPS only; query parameters are encoded by requests.
 MAPQUEST_GEOCODE_URL = "https://www.mapquestapi.com/geocoding/v1/address"
@@ -84,16 +87,29 @@ def main():
         description="Retrieve latitude and longitude for a given city or town using the MapQuest Geocoding API."
     )
     parser.add_argument("location", help="City or town name")
-    parser.add_argument("--api-key", required=True, help="MapQuest API key")
+    parser.add_argument(
+        "--api-key",
+        help=f"MapQuest API key (defaults to the {API_KEY_ENV_VAR} environment variable)",
+    )
     args = parser.parse_args()
 
     location = (args.location or "").strip()
     if not location:
         parser.error("location must not be empty.")
 
-    api_key = (args.api_key or "").strip()
-    if not api_key:
-        parser.error("--api-key must not be empty.")
+    if args.api_key is not None:
+        # An explicit flag is treated as authoritative; an empty value is an error
+        # rather than silently falling back to the environment.
+        api_key = args.api_key.strip()
+        if not api_key:
+            parser.error("--api-key must not be empty.")
+    else:
+        api_key = (os.environ.get(API_KEY_ENV_VAR) or "").strip()
+        if not api_key:
+            parser.error(
+                f"an API key is required: pass --api-key or set the {API_KEY_ENV_VAR} "
+                "environment variable."
+            )
 
     lat, lng = get_coordinates(api_key, location)
 

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -1,10 +1,16 @@
 import io
+import os
 import unittest
 from unittest.mock import MagicMock, patch
 
 import requests
 
-from mapquest_geocoder.geocode import MAPQUEST_GEOCODE_URL, get_coordinates, main
+from mapquest_geocoder.geocode import (
+    API_KEY_ENV_VAR,
+    MAPQUEST_GEOCODE_URL,
+    get_coordinates,
+    main,
+)
 
 
 class TestGetCoordinates(unittest.TestCase):
@@ -128,9 +134,58 @@ class TestMain(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
 
     def test_empty_api_key_exits_with_code_2(self):
-        with patch("sys.argv", ["prog", "Paris", "--api-key", "  "]):
-            with self.assertRaises(SystemExit) as ctx:
-                main()
+        with patch.dict(os.environ, {API_KEY_ENV_VAR: "env_key"}, clear=False):
+            with patch("sys.argv", ["prog", "Paris", "--api-key", "  "]):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
+        # An explicit empty flag is an error even when the env var is set.
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_api_key_from_environment_when_flag_absent(self):
+        payload = {
+            "info": {"statuscode": 0},
+            "results": [{"locations": [{"latLng": {"lat": 5.0, "lng": 6.0}}]}],
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = payload
+
+        with patch.dict(os.environ, {API_KEY_ENV_VAR: "env_key"}, clear=False):
+            with patch(
+                "mapquest_geocoder.geocode.requests.get", return_value=mock_resp
+            ) as mock_get:
+                with patch("sys.argv", ["prog", "Paris"]):
+                    with self.assertRaises(SystemExit) as ctx:
+                        main()
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertEqual(mock_get.call_args.kwargs["params"]["key"], "env_key")
+
+    def test_flag_overrides_environment(self):
+        payload = {
+            "info": {"statuscode": 0},
+            "results": [{"locations": [{"latLng": {"lat": 5.0, "lng": 6.0}}]}],
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = payload
+
+        with patch.dict(os.environ, {API_KEY_ENV_VAR: "env_key"}, clear=False):
+            with patch(
+                "mapquest_geocoder.geocode.requests.get", return_value=mock_resp
+            ) as mock_get:
+                with patch("sys.argv", ["prog", "Paris", "--api-key", "flag_key"]):
+                    with self.assertRaises(SystemExit):
+                        main()
+
+        self.assertEqual(mock_get.call_args.kwargs["params"]["key"], "flag_key")
+
+    def test_missing_key_and_env_exits_with_code_2(self):
+        env_without_key = {k: v for k, v in os.environ.items() if k != API_KEY_ENV_VAR}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            with patch("sys.argv", ["prog", "Paris"]):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
         self.assertEqual(ctx.exception.code, 2)
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Makes `--api-key` optional and falls back to the `MAPQUEST_API_KEY` environment variable, so users don't have to pass their key on every invocation (and keep it out of shell history).

## Behavior
- `--api-key` flag takes precedence when provided.
- When `--api-key` is omitted, the key is read from `MAPQUEST_API_KEY`.
- An explicitly provided but empty `--api-key` is still an error (exit 2) — it does not silently fall back to the env var.
- If neither the flag nor the env var provides a key, the CLI errors with a clear message (exit 2).

## Usage
```
export MAPQUEST_API_KEY=YOUR_API_KEY
mapquest-geocode "New York"
# or, as before:
mapquest-geocode "New York" --api-key YOUR_API_KEY
```

## Tests
Added unit tests (mocked, no network/key needed):
- env var used when flag absent
- flag overrides env var
- missing flag + missing env var → exit 2
- existing "empty `--api-key` → exit 2" updated to assert it errors even when the env var is set

## Verification
- `.venv/bin/python -m unittest discover -s tests` — 16/16 pass
- `pyflakes` — no issues
- Manual CLI checks: `--help` shows the optional flag; missing key errors with exit 2; env-var path reaches the live API (HTTP 401 with a dummy key, as expected without a valid key)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-674c75e6-d55e-47ff-b277-883bda2d8b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-674c75e6-d55e-47ff-b277-883bda2d8b4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

